### PR TITLE
Fix typo on Program Tools

### DIFF
--- a/_includes/program-tools.html
+++ b/_includes/program-tools.html
@@ -224,7 +224,7 @@
         </div>
         <div class="accordion__bd">
             <div>
-                <p>Microsoft has developed and adopted several different approaces to
+                <p>Microsoft has developed and adopted several different approaches to
                     retrieving GitHub data about activity within our organizations: we use
                     the GitHub REST API v3 and GraphQL to regularly make data about
                     our GitHub repos, traffic data, issues and pull requests all available inside


### PR DESCRIPTION
Changes `approaces` to `approaches`