### PR TITLE
New Code of Conduct and FAQ versions

### DIFF
--- a/_data/cocfaq.yml
+++ b/_data/cocfaq.yml
@@ -9,7 +9,7 @@
     </ul>
 
 - question: Why this Code of Conduct?
-  answer: The Microsoft Open Source Code of Conduct is an instantiation of the <a href="https://todogroup.org/" target="_blank" rel= "noopener">TODO Group</a> Code of Conduct template, that captures the Microsoft culture of equality, respect and inclusion. This same template is used by industry colleagues such as Facebook, Twitter, GitHub, Yahoo and others in their open source projects.
+  answer: The Microsoft Open Source Code of Conduct is an instantiation of the  <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct/">Contributor's Covenant 2.0</a>, that captures the Microsoft culture of equality, respect and inclusion. By leveraging this template, which is used by many <a href="https://www.contributor-covenant.org/adopters/">open source projects</a>, we acknowledge both the opportunity gained by leveraging a community-based effort for inclusion,  and responsibility to contribute to its evolution.
 
 
 - question: Why do this across all repos?
@@ -17,15 +17,7 @@
 
 - question: How does a project adopt the code and process?
   answer: |
-    All Microsoft projects are automatically covered by the Code of Conduct and the Issue Resolution Process. However, it is critical that everyone in the communities be aware of the code and process. For that reason, all projects must link to the Code of Conduct in their README and/or CONTRIBUTING files using the following markdown.<br><br>
-    <pre>
-    This project has adopted the [Microsoft Open Source Code of
-    Conduct](https://opensource.microsoft.com/codeofconduct/).
-    For more information see the [Code of Conduct
-    FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
-    contact [opencode@microsoft.com](mailto:opencode@microsoft.com)
-    with any additional questions or comments.
-    </pre>
+    <p>All Microsoft projects are automatically covered by the Code of Conduct and the Issue Resolution Process. However, it is critical that everyone in the communities be aware of the code and process. For that reason, all projects must link to the Code of Conduct. Please refer to this <a href="https://github.com/microsoft/repo-templates/blob/main/shared/CODE_OF_CONDUCT.md">repository standard</a> for the current CODE_OF_CONDUCT.md version.</p>
 
 
 - question: What if my Microsoft project already has a Code of Conduct?
@@ -36,27 +28,28 @@
 
 - question: How do I raise a concern?
   answer: |
-   <p>If you have witnessed or been subjected to a violation of the Code of Conduct, please send an email to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a>. Your message will be handled in a secure and confidential manner. This email address is monitored by people who are not active in open source projects or communities — so you can be sure that you are not communicating with a person involved in the issue you are reporting. You will receive a response within one business day acknowledging receipt of your email and describing the process for its resolution. (See below for more details.)</p>
-
+   <p>If you have witnessed or been subjected to a violation of the Code of Conduct, please send an email to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a>. Your message will be handled in a secure and confidential manner. This email address is monitored by the Open Source Program's Office, who are not directly active in open source projects or communities — so you can be sure that you are not communicating with a person involved in the issue you are reporting.</p>
+   <p> You will receive a response within one business day acknowledging receipt of your email and describing the process for its resolution. (See below for more details.)</p>
+   <p>NOTE: this process is not appropriate for reporting spamming. Please reach out to <a href="https://support.github.com/contact">GitHub Support</a> for these issues.</p>
 - question: What is the process for addressing issues that arise?
   answer: |
-    <p>Emails sent to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a> kick off the following process:</p>
+    <p>Emails sent to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a> or reported directly to a member of the OSPO team,  kick off the following process:</p>
     <ol>
         <li><span>Your message will be acknowledged within one business day.</span></li>
-        <li><span>Within the following business day, a small, 2-3, person team will be assembled from a pool of Microsoft employee volunteers to review your concern. This team will be as diverse as possible given its size and will pull in additional people as needed to gain further insight and provide guidance. The team will not include anyone directly involved in the issue that has been raised.</span></li>
-        <li><span>From there team will work with you and the others involved to come to a conclusion. While issue complexity varies, the goal is to resolve issues within five working days.</span></li>
+        <li><span>Within the following business day a small, (2-3) person team will be assembled from a pool of Microsoft employee volunteers to review your concern. This team will be as diverse as possible given its size and will pull in additional people as needed to gain further insight and provide guidance. The team will not include anyone directly involved in the issue that has been raised.</span></li>
+        <li><span>From there the team will work with you and the others involved to come to a conclusion. While issue complexity varies, the goal is to resolve issues within five working days.</span></li>
         <li><span>All communication will be confidential with very limited circulation.</span></li>
     </ol>
     <div class="pre">
         <div>
             <p>Step 1: Issue Reported</p>
-            <p><span class="org">Originator</span> reports issue via email to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a></p>
+            <p><span class="org">Reporter</span> reports directly to a member of the OSPO team or via email to <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a></p>
             <small>Email address is published with Code of Conduct, linked from every Microsoft Open Source project’s repo.</small>
             <hr>
         </div>
         <div>
             <p>Step 2: Acknowledgment</p>
-            <p><span class="co">Coordinator</span> acknowledges to <span class="org">Originator</span> receipt of issue</p>
+            <p><span class="co">Coordinator</span> acknowledges to <span class="org">Reporter</span> receipt of issue</p>
             <small>Coordinator replies via email to set expectations and explain resolution process.</small>
             <hr>
         </div>
@@ -68,21 +61,16 @@
         </div>
         <div>
             <p>Step 4: Resolution</p>
-            <p><span class="rt">Resolution Team</span> to works with to solve the issue <span class="org">Originator</span>.</p>
+            <p><span class="rt">Resolution Team</span> to works with to solve the issue <span class="org">in coordination with the Reporter</span>.</p>
             <small>Resolution Team contacts Originator to collect information as needed, agree on appropriate steps, and drive resolution.</small>
         </div>
     </div>
-
-
 - question: How does the resolution team work?
   answer: |
     <p>Beyond the norms and values set out in the Code of Conduct, issue review teams operate under the following principles:</p>
     <ul>
-        <li><b>Less is more</b> — As much as possible, let the community work it out. It is much better to have communities self-correct than to have outsiders come in and “fix” problems.</li>
+        <li><b>Safety & Privacy</b> — Safety and privacy of all involved are at the center of resolution procedure.</li>
         <li><b>Equality</b> — Contribution value or status in the community are not relevant to the review. Key people do not have more rights (either to abuse or be protected from abuse) than others in the community.</li>
         <li><b>Independence</b> — Reviewers must act and be seen to act with independence from the project(s) in question and from Microsoft.</li>
+        <li><b>Consequence</b> - If a report is validated by the resolution team, appropriate consequences will be applied. These can be very minimal (written warning) or serious (full ban) depending on the violation. Repeated violations will result in escalation of consequence.</li>
     </ul>
-
-- question: Can I use this Code of Conduct in my projects?
-  answer: |
-    <p>Yes. The document is licenced under <a href="https://creativecommons.org/licenses/by/4.0">CC BY 4.0</a>. You will of course need to update the document to suit the specifics of your projects, but by all means use this however you can to drive great communities.</p>

--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -31,88 +31,57 @@ title: Code of Conduct
 
             <br />
             <br />
+
             <div class="pb-6">
-                <p>Our open source communities strive to:</p>
-                <ul>
-                    <li>
-                        <b>Be friendly and patient:</b> Remember you might not be communicating in someone else's primary spoken or programming language, and others may not have your level of understanding.
-                    </li>
-                    <li>
-                        <b>Be welcoming:</b> Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-                    </li>
-                    <li>
-                        <b>Be respectful:</b> We are a world-wide community of professionals, and we conduct ourselves professionally. Disagreement is no excuse for poor behavior and poor manners. Disrespectful and unacceptable behavior includes, but is not limited to:
-                        <ul>
-                            <li>
-                                Violent threats or language.
-                            </li>
-                            <li>
-                                Discriminatory or derogatory jokes and language.
-                            </li>
-                            <li>
-                                Posting sexually explicit or violent material.
-                            </li>
-                            <li>
-                                Posting, or threatening to post, people's personally identifying information ("doxing").
-                            </li>
-                            <li>
-                                Insults, especially those using discriminatory terms or slurs.
-                            </li>
-                            <li>
-                                Behavior that could be perceived as sexual attention.
-                            </li>
-                            <li>
-                                Advocating for or encouraging any of the above behaviors.
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <b>Understand Disagreements:</b> Disagreements, both social and technical, are useful learning opportunities. Seek to understand the other viewpoints and resolve differences constructively.
-                    </li>
-                    <li>
-                        This code is not exhaustive or complete. It serves to capture our common understanding of a productive, collaborative environment. We expect the code to be followed in spirit as much as in the letter.
-                    </li>
-                </ul>
+                <h3 class="h3">Our Pledge</h3>
+                <p>We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.</p>
 
+                <p>We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.</p>
             </div>
+            <div class="pb-6">
+                <h3 class="h3">Our Standards</h3>
+                <p>Examples of behavior that contributes to a positive environment for our community include:.</p>
+                 <ul>
+                     <li>Demonstrating empathy and kindness toward other people</li>
+                     <li>Being respectful of differing opinions, viewpoints, and experiences</li>
+                     <li>Giving and gracefully accepting constructive feedback</li>
+                     <li>Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience</li>
+                     <li>Focusing on what is best not just for us as individuals, but for the overall community</li>
+                </ul>
+                <br />
+                <p>Examples of unacceptable behavior include:</p>
+                <ul>
+                    <li>The use of sexualized language or imagery, and sexual attention or advances of any kind</li>
+                    <li>Trolling, insulting or derogatory comments, and personal or political attacks</li>
+                    <li>Public or private harassment</li>
+                    <li>Disruptive behavior</li>
+                    <li>Publishing others' private information, such as a physical or email address, without their explicit permission</li>
+                    <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
+                </ul>
+            </div>
+            <div class="pb-6">
+                <h3 class="h3">Enforcement Responsibilities</h3>
+                <p>Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.</p>
 
+                <p>Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.</p>
+            </div>
             <div class="pb-6">
                 <h3 class="h3">Scope</h3>
-                <p>This code of conduct applies to all repos and communities for Microsoft-managed open source projects regardless of whether or not the repo explicitly calls out its use of this code. The code also applies in public spaces when an individual is representing a project or its community. Examples include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.</p>
-
-                <p>Note: Some Microsoft-managed communities have codes of conduct that pre-date this document and issue resolution process. While communities are not required to change their code, they are expected to use the resolution process outlined here. The review team will coordinate with the communities involved to address your concerns.</p>
+                <p>This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.</p>
+                <p>This Code of Conduct also applies to actions taken outside of these spaces, and which have a negative impact on community health.</p>
             </div>
-
             <div class="pb-6">
-                <h3 class="h3">Reporting Code of Conduct Issues</h3>
-                <p>We encourage all communities to resolve issues on their own whenever possible. This builds a broader and deeper understanding and ultimately a healthier interaction. In the event that an issue cannot be resolved locally, please feel free to report your concerns by contacting <a href="mailto:opencode@microsoft.com">opencode@microsoft.com</a>. Your report will be handled in accordance with the issue resolution process described in the <a href="{{ '/codeofconduct/faq/' | relative_url }}">Code of Conduct FAQ</a>.</p>
-
-                <p>In your report please include:</p>
-
-                <ul>
-                    <li>
-                        Your contact information.
-                    </li>
-                    <li>
-                        Names (real, usernames or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well.
-                    </li>
-                    <li>
-                        Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public chat log), please include a link or attachment.
-                    </li>
-                    <li>
-                        Any additional information that may be helpful.
-                    </li>
-                </ul>
-
-                <p>All reports will be reviewed by a multi-person team and will result in a response that is deemed necessary and appropriate to the circumstances. Where additional perspectives are needed, the team may seek insight from others with relevant expertise or experience. The confidentiality of the person reporting the incident will be kept at all times. Involved parties are never part of the review team.</p>
-
-                <p>Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the review team may take any action they deem appropriate, including a permanent ban from the community.</p>
-
-                <p>This code of conduct is based on the template established by the <a href="https://todogroup.org/" rel="noopener" target="_blank">TODO Group</a> and used by numerous other large communities (e.g., Facebook, Twitter, GitHub) and the Scope section from the <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct/" target="_blank" rel="noopener">Contributor Covenant version 1.4</a>.</p>
+                <h3 class="h3">Enforcement and Reporting</h3>
+                <p> We encourage all communities to resolve issues on their own whenever possible. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opencode@microsoft.com.</p>
+                <p>Your report will be handled in accordance with the issue resolution process described in the Code of Conduct FAQ.
+                All project and communiy leaders are obligated to respect the privacy and security of the reporter of any incident.</p> 
             </div>
+            <div class="pb-6">
+                <h3 class="h3">Attribution</h3>
+                <p>This Code of Conduct is adapted from the <a href="https://www.contributor-covenant.org">Contributor Covenant</a>, version 2.0, available at <a href="https://www.contributor-covenant.org/version/2/0/code_of_conduct.html">https://www.contributor-covenant.org/version/2/0/code_of_conduct.html</a>.</p>
+                <p>Community Impact Guidelines were inspired by <a href="https://github.com/mozilla/diversity">Mozilla's code of conduct enforcement ladder</a>.</p>
+                <p>Expanding scope to include external impact on community health inspired by <a href="https://opensource.facebook.com/code-of-conduct">Facebook's Open Source Code of Conduct</a> and <a href="https://www.mozilla.org/en-US/about/governance/policies/participation/">Mozilla's Community Participation Guidelines</a>.</p>
+                <p>For answers to common questions about this code of conduct, see the FAQ at <a href="https://www.contributor-covenant.org/faq">https://www.contributor-covenant.org/faq</a>. Translations are available at <a href="https://www.contributor-covenant.org/translations">https://www.contributor-covenant.org/translations</a>.</p>
         </div>
     </div>
-
-
-
 </article>


### PR DESCRIPTION
**Release Notes:**

- Updated Code of Conduct from Now archived TODO group version,  to Contributor's Covenant 2.0 with modifications.  Those modifications are: removal of the the Enforcement Guidelines section (related language in FAQ); addition of new line to under 'Scope' to include external influence on community health (inspired by Mozilla's CPG, and Facebook's Open Source CoC) addressing the same. This also adds 'disruptive behavior' as an example of unacceptable behavior inspired by Mozilla's CPG.
-  Updated Code of Conduct FAQ to reference the above change.   Also updated were standards for GitHub repository CODE_OF_CONDUCT.md,  change of language from 'orginator' to 'reporter', addition of reporting to include 'anyone on the OSPO team' instead of just an alias. Also added: 'Safety & Privacy' and 'Consequence' to describe how resolution team works, and potential outcomes.  Added: a new note to redirect spamming concerns to GitHub support.

Special thanks to contributors in this work,:  
* @AevaOnline 
* @carolynvs
*  @chwarr
* @kcpeppe 
* @molant 
