### PR TITLE
Revert "correct spelling mistake"

### DIFF
--- a/code-of-conduct.html
+++ b/code-of-conduct.html
@@ -74,7 +74,7 @@ title: Code of Conduct
                 <h3 class="h3">Enforcement and Reporting</h3>
                 <p> We encourage all communities to resolve issues on their own whenever possible. Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at opencode@microsoft.com.</p>
                 <p>Your report will be handled in accordance with the issue resolution process described in the Code of Conduct FAQ.
-                All project and community leaders are obligated to respect the privacy and security of the reporter of any incident.</p> 
+                All project and communiy leaders are obligated to respect the privacy and security of the reporter of any incident.</p> 
             </div>
             <div class="pb-6">
                 <h3 class="h3">Attribution</h3>


### PR DESCRIPTION
Reverts microsoft/opensource.microsoft.com#98