### PR TITLE
Update FreeBSD credits to Unix-like

### DIFF
--- a/_includes/credits-overview.html
+++ b/_includes/credits-overview.html
@@ -17,7 +17,7 @@
       <li>
           <b>FreeBSD</b>
           <br />
-          FreeBSD is a Unix operating system for servers, desktops, and embedded platforms. Azure credits have helped developers to work on custom kernels. 
+          FreeBSD is a Unix-like operating system for servers, desktops, and embedded platforms. Azure credits have helped developers to work on custom kernels. 
         They are now releasing more timely updates for security advisories for third-party software and spinning up larger VM classes for package building 
         and smaller VM classes for testing, both of which are hugely helpful to their developers.
       </li>


### PR DESCRIPTION
Changes Wording of freebsd credits to Unix-like instead of Unix because Unix is a registered trademark