### PR TITLE
Fix docker build in Dockerfile and Dockerfile.builder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/builder as build
+FROM jekyll/builder:4.2.0 as build
 WORKDIR /tmp
 COPY . /tmp
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM jekyll/builder as build
+FROM jekyll/builder:4.2.0 as build
 
 RUN apk update && apk add --no-cache zip
 


### PR DESCRIPTION
## Why

I want to enable testing this repository somewhere(local PC / Github Actions).
This repository can not build a docker container.(both Dockerfile and Dockerfile.builder)

## What

Fix docker build.

- First, I checked `jekyll/builder:latest` image. ref https://hub.docker.com/r/jekyll/builder/tags?page=1


This image is upgraded on July 10, 2022. (Ruby version is 3.x) ref https://hub.docker.com/layers/builder/jekyll/builder/latest/images/sha256-5be62bc53f7f94662098d634410460321b6f5b038144251ed925d312c3c28c3c?context=explore

![image](https://user-images.githubusercontent.com/2929102/182328153-70077f64-308c-490a-adac-2cc1e151c4e0.png)

- Second, I checked GitHub Actions log. ref https://github.com/microsoft/opensource.microsoft.com/actions/workflows/builder.yml

This build seemed to be working until 4 months ago.

![image](https://user-images.githubusercontent.com/2929102/182330495-a1b9939a-ca6b-4d81-acdc-f882a483dc89.png)


- Third, I checked commit log about `Dockerfile` and `Dockerfile.builder` ref https://github.com/microsoft/opensource.microsoft.com/tree/807ebaf21d11f1a5c284387696cca0ce4b62057f

It seems to have remained the same for two years. So, the recent `jekyll/builder` update changed the ruby version, and `docker build .` no longer works.

I think this repository uses the previous ruby version(2.x).

https://hub.docker.com/layers/builder/jekyll/builder/4.2.0/images/sha256-ad2fe75e0f7d82907ea84cc3d5dd649a6f26c5f165c851b07e4a3369d08f6c4f?context=explore
![image](https://user-images.githubusercontent.com/2929102/182328363-e4b9db8c-503e-4d6d-a05c-d88b8c208596.png)

![image](https://user-images.githubusercontent.com/2929102/182327862-6623e918-fccc-46c3-91f2-e3fe9b252e34.png)

## e2e test log

- before

```console
$ docker build .      
[+] Building 15.7s (14/18)                                                                                                            
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 366B                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                  2.5s
 => [internal] load metadata for docker.io/jekyll/builder:latest                                                                 2.5s
 => [auth] jekyll/builder:pull token for registry-1.docker.io                                                                    0.0s
 => [auth] library/nginx:pull token for registry-1.docker.io                                                                     0.0s
 => [build 1/9] FROM docker.io/jekyll/builder@sha256:5be62bc53f7f94662098d634410460321b6f5b038144251ed925d312c3c28c3c            0.0s
 => [stage-1 1/2] FROM docker.io/library/nginx:alpine@sha256:9c2030e1ff2c3fef7440a7fb69475553e548b9685683bdbf669ac0829b889d5f    0.0s
 => [internal] load build context                                                                                                0.1s
 => => transferring context: 54.50kB                                                                                             0.1s
 => CACHED [build 2/9] WORKDIR /tmp                                                                                              0.0s
 => [build 3/9] COPY . /tmp                                                                                                      0.1s
 => [build 4/9] RUN addgroup oss && adduser -D -G oss oss && chown -R oss:oss .                                                  0.7s
 => [build 5/9] RUN chown -R oss:oss /usr/gem                                                                                    7.1s
 => ERROR [build 6/9] RUN bundle install                                                                                         4.7s
------                                                                                                                                
 > [build 6/9] RUN bundle install:                                                                                                    
#14 0.487 Bundler 2.3.17 is running, but your lockfile was generated with 2.1.4. Installing Bundler 2.1.4 and restarting using that version.                                                                                                                                
#14 1.715 Fetching gem metadata from https://rubygems.org/.                                                                           
#14 1.760 Fetching bundler 2.1.4                                                                                                      
#14 1.911 Installing bundler 2.1.4
#14 2.980 Fetching gem metadata from https://rubygems.org/.........
#14 4.638 listen-3.2.1 requires ruby version >= 2.2.7, ~> 2.2, which is incompatible with
#14 4.638 the current version, ruby 3.1.1p18
------
executor failed running [/bin/sh -c bundle install]: exit code: 5

```

- after

```console
$ docker build .
[+] Building 99.0s (19/19) FINISHED                                                                                                   
 => [internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 372B                                                                                             0.0s
 => [internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                  2.2s
 => [internal] load metadata for docker.io/jekyll/builder:4.2.0                                                                  2.2s
 => [auth] jekyll/builder:pull token for registry-1.docker.io                                                                    0.0s
 => [auth] library/nginx:pull token for registry-1.docker.io                                                                     0.0s
 => [build 1/9] FROM docker.io/jekyll/builder:4.2.0@sha256:ad2fe75e0f7d82907ea84cc3d5dd649a6f26c5f165c851b07e4a3369d08f6c4f      0.0s
 => [internal] load build context                                                                                                1.2s
 => => transferring context: 11.51MB                                                                                             1.2s
 => CACHED [stage-1 1/2] FROM docker.io/library/nginx:alpine@sha256:9c2030e1ff2c3fef7440a7fb69475553e548b9685683bdbf669ac0829b8  0.0s
 => CACHED [build 2/9] WORKDIR /tmp                                                                                              0.0s
 => [build 3/9] COPY . /tmp                                                                                                      0.1s
 => [build 4/9] RUN addgroup oss && adduser -D -G oss oss && chown -R oss:oss .                                                  0.8s
 => [build 5/9] RUN chown -R oss:oss /usr/gem                                                                                    8.5s
 => [build 6/9] RUN bundle install                                                                                              15.0s
 => [build 7/9] RUN npm install                                                                                                 62.2s
 => [build 8/9] RUN ./node_modules/gulp/bin/gulp.js build                                                                        5.2s 
 => [build 9/9] RUN jekyll build                                                                                                 2.3s 
 => [stage-1 2/2] COPY --from=build /tmp/_site /usr/share/nginx/html                                                             0.3s 
 => exporting to image                                                                                                           0.4s 
 => => exporting layers                                                                                                          0.3s 
 => => writing image sha256:9aec54379e6b3c46d6b945efa1b811a0284b4480c37cc6791324d56142fe8c99                                     0.0s 
                                                                                                                                      
Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them  
```

- check

```console
$ docker run -p 8080:80 9aec54379e6b3c46d6b945efa1b811a0284b4480c37cc6791324d56142fe8c99
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2022/08/02 08:28:49 [notice] 1#1: using the "epoll" event method
2022/08/02 08:28:49 [notice] 1#1: nginx/1.23.1
2022/08/02 08:28:49 [notice] 1#1: built by gcc 11.2.1 20220219 (Alpine 11.2.1_git20220219) 
2022/08/02 08:28:49 [notice] 1#1: OS: Linux 5.10.104-linuxkit
2022/08/02 08:28:49 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2022/08/02 08:28:49 [notice] 1#1: start worker processes
2022/08/02 08:28:49 [notice] 1#1: start worker process 32
2022/08/02 08:28:49 [notice] 1#1: start worker process 33
2022/08/02 08:28:49 [notice] 1#1: start worker process 34
2022/08/02 08:28:49 [notice] 1#1: start worker process 35
2022/08/02 08:28:49 [notice] 1#1: start worker process 36
2022/08/02 08:28:49 [notice] 1#1: start worker process 37
```

![image](https://user-images.githubusercontent.com/2929102/182329519-82d6d3a3-1b83-41d0-884e-968864eb8df3.png)

