### PR TITLE
Support remote container(devcontainer)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/docker-existing-dockerfile
+{
+	"name": "Existing Dockerfile",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../Dockerfile.builder"
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,26 +1,5 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.241.1/containers/docker-existing-dockerfile
 {
-	"name": "Existing Dockerfile",
-
-	// Sets the run context to one level up instead of the .devcontainer folder.
-	"context": "..",
-
-	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
-	"dockerFile": "../Dockerfile.builder"
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	"name": "opensource.microsoft.com Development Environment",
+	"dockerFile": "../Dockerfile.builder",
 	"postCreateCommand": "jekyll server",
-
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
-	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	// "forwardPorts": [],
 
 	// Uncomment the next line to run commands after the container is created - for example installing curl.
-	// "postCreateCommand": "",
+	"postCreateCommand": "jekyll server",
 
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],


### PR DESCRIPTION
## Why

Easy setup for contributors.

## What

Add remote container(.devcontainer)


### Dockerfile vs Dockerfile.builder

[Dockerfile](https://github.com/microsoft/opensource.microsoft.com/blob/b5725c8e9b7058bdf604e66f39a6bf37c5b5a0ea/Dockerfile) is the nginx container after `jekyll build`. If you are using it in a development environment, I thought it would be appropriate to use [Dockerfile.builder](https://github.com/microsoft/opensource.microsoft.com/blob/b5725c8e9b7058bdf604e66f39a6bf37c5b5a0ea/Dockerfile.builder), which can run the `jekyll server`.

## log

![image](https://user-images.githubusercontent.com/2929102/182509233-02f282f3-ef10-42b5-aa0d-279a4cad506a.png)

```console
Running the postCreateCommand from devcontainer.json...

[13346 ms] Start: Run in container: /bin/sh -c jekyll server
Configuration file: /workspaces/opensource.microsoft.com/_config.yml
            Source: /workspaces/opensource.microsoft.com
       Destination: /workspaces/opensource.microsoft.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
       Jekyll Feed: Generating feed for posts
                    done in 9.705 seconds.
 Auto-regeneration: enabled for '/workspaces/opensource.microsoft.com'
    Server address: http://127.0.0.1:4000
  Server running... press ctrl-c to stop.
```

![image](https://user-images.githubusercontent.com/2929102/182509373-70543dcd-3e8b-44df-8e2d-28db81a5c7c1.png)
