### PR TITLE
Patched xmlhttprequest-ssl CVE-2021-31597

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2368,7 +2368,7 @@
         "parseqs": "0.0.5",
         "parseuri": "0.0.5",
         "ws": "~6.1.0",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -7765,7 +7765,7 @@
             "parseqs": "0.0.5",
             "parseuri": "0.0.5",
             "ws": "~3.3.1",
-            "xmlhttprequest-ssl": "~1.5.4",
+            "xmlhttprequest-ssl": "~1.6.2",
             "yeast": "0.1.2"
           }
         },
@@ -8928,7 +8928,7 @@
       }
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
+      "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
       "dev": true


### PR DESCRIPTION
## Descriptions issue:
The xmlhttprequest-ssl package before 1.6.1 for Node.js disables SSL certificate validation by default, because rejectUnauthorized (when the property exists but is undefined) is considered to be false within the https.request function of Node.js. In other words, no certificate is ever rejected.

**CVE-2021-31597**
`9.4 / 10`

Best Regards,
@imhunterand

