### PR TITLE
Pached Arbitrary File Creation/Overwrite on Windows via insufficient relative path sanitization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,9 +1872,9 @@
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
+        "decompress-tar": "^4.4.18",
+        "decompress-tarbz2": "^4.4.18",
+        "decompress-targz": "^4.4.18",
         "decompress-unzip": "^4.0.1",
         "graceful-fs": "^4.1.10",
         "make-dir": "^1.0.0",


### PR DESCRIPTION
## Description issue:
Arbitrary File Creation, Arbitrary File Overwrite, Arbitrary Code Execution

node-tar aims to guarantee that any file whose location would be outside of the extraction target directory is not extracted. This is, in part, accomplished by sanitizing absolute paths of entries within the archive, skipping archive entries that contain `..` path portions, and resolving the sanitized paths against the extraction target directory.

This logic was insufficient on Windows systems when extracting tar files that contained a path that was not an absolute path, but specified a drive letter different from the extraction target, such as `C:some\path`. If the drive letter does not match the extraction target, for example `D:\extraction\dir`, then the result of `path.resolve(extractionDirectory, entryPath)` would resolve against the current working directory on the `C:` drive, rather than the extraction target directory.

Additionally, a `..` portion of the path could occur immediately after the drive letter, such as `C:../foo`, and was not properly sanitized by the logic that checked for `..` within the normalized and split portions of the path.

This only affects users of `node-tar` on Windows systems.

**CVE-2021-37713**
`8.2/ 10`

**Patches**
4.4.18 || 5.0.10 || 6.1.9

## Workarounds
There is no reasonable way to work around this issue without performing the same path normalization procedures that node-tar now does.
Users are encouraged to upgrade to the latest patched versions of node-tar, rather than attempt to sanitize paths themselves.

## Fix
The fixed versions strip path roots from all paths prior to being resolved against the extraction target folder, even if such paths are not "absolute".

Additionally, a path starting with a drive letter and then two dots, like `c:../`, would bypass the check for `..` path portions. This is checked properly in the patched versions.

Finally, a defense in depth check is added, such that if the `entry.absolute` is outside of the extraction taret, and we are not in preservePaths:true mode, a warning is raised on that entry, and it is skipped. Currently, it is believed that this check is redundant, but it did catch some oversights in development.