### PR TITLE
Adding a page about the Contributor License Agreement

### DIFF
--- a/cla.html
+++ b/cla.html
@@ -48,22 +48,25 @@ permalink: /cla/
                         bot.
                     </li>
                     <li>
-                        If you've signed the CLA before, the status check goes green, and you're done, your
-                        pull request is ready to be reviewed and merged.
+                        If you've signed the CLA before, the status check goes green, and you're done.
+                        Your pull request is ready to be reviewed and merged.
                     </li>
                     <li>
-                        If you have not signed the CLA, the pull request will receive a comment annotated 
-                        with the agreement and more information about signing the agreement. You will reply
-                        with a comment if you accept the agreement yourself, or, if you've been authorized to
-                        sign it on behalf of your company, there is syntax for that as well.
+                        If you have not signed the CLA at any point before, the pull request will
+                        receive a comment annotated with the agreement and more information about
+                        signing the agreement. You will reply with a comment to accept the agreement
+                        on behalf of yourself, or, if you've been authorized to sign on behalf of
+                        your company, there is a different syntax for that.
                     </li>
                     <li>
                         After signing, the status check will pass and you're all set. <strong>Thanks for your contribution!</strong>
                     </li>
                     <li>
                         <em>NOTE:</em><br />
-                        If you're an active Microsoft employee or vendor, and have a linked GitHub account,
-                        the check will also go green. Microsoft employees can learn more about linking at 
+                        If you're an active Microsoft employee or vendor, there is a Microsoft-internal
+                        system that allows you to "link" your GitHub account for corporate use. When you
+                        use your linked your account, you will not have to sign the CLA. Microsoft
+                        employees and vendors can learn more about linking accounts at 
                         <a href="https://aka.ms/opensource" target="_new">aka.ms/opensource</a>.
                     </li>
                 </ul>

--- a/cla.html
+++ b/cla.html
@@ -1,0 +1,31 @@
+---
+layout: default
+id: cla
+title: Contributor License Agreements at Microsoft
+permalink: /cla/
+---
+
+<article class="program-page">
+    <div class="page-header">
+        <div class="wrapper">
+            <div class="col-md-10 col-lg-7 mx-auto">
+                <h1 class="h2">Contributor License Agreements</h2>
+            </div>
+        </div>
+    </div>
+    <div class="wrapper-full bg-light">
+        <div class="wrapper my-6 py-4">
+            <div class="col-md-10 col-lg-7 mx-auto">
+                <h3 class="h4 font-weight-400 mb-4">
+                  Microsoft projects have a Contributor License Agreement (CLA). The Microsoft 
+                  CLA only needs to be agreed to once. We aim to make participating as easy
+                  and efficient as possible, and thank you for your contributions to the
+                  open source ecosystem.
+                </h3>
+            </div>
+        </div>
+    </div>
+
+    <!-- TODO: additional content -->
+
+</article>

--- a/cla.html
+++ b/cla.html
@@ -17,15 +17,101 @@ permalink: /cla/
         <div class="wrapper my-6 py-4">
             <div class="col-md-10 col-lg-7 mx-auto">
                 <h3 class="h4 font-weight-400 mb-4">
-                  Microsoft projects have a Contributor License Agreement (CLA). The Microsoft 
-                  CLA only needs to be agreed to once. We aim to make participating as easy
-                  and efficient as possible, and thank you for your contributions to the
-                  open source ecosystem.
+                    We appreciate community contributions to Microsoft repositories. By
+                    signing a contributor license agreement, we ensure that the
+                    community is free to use your contributions.
                 </h3>
             </div>
         </div>
     </div>
 
-    <!-- TODO: additional content -->
+
+    <div class="wrapper my-6 py-4">
+        <div class="col-md-10 col-lg-7 mx-auto longform">
+            <p class="p-lg">
+                TBD.
+            </p>
+
+            <br />
+            <br />
+
+            <div class="pb-6">
+                <h3 class="h3">Review the CLA document</h3>
+                <p>
+                    Download the <a href="/pdf/microsoft-contribution-license-agreement.pdf" target="_new">Microsoft Contributor License Agreement (CLA) PDF</a> document if you need.
+                </p>
+            </div>
+            <div class="pb-6">
+                <h3 class="h3">Signing the CLA</h3>
+                <p>
+                    The Microsoft CLA experience is integrated natively into GitHub and its pull request
+                    experience. Here's how it works the first time you contribute to a Microsoft open source
+                    project:
+                </p>
+                 <ul>
+                    <li>
+                        When you open a pull request, the <code>license/cla</code> check is run by our 
+                        bot.
+                    </li>
+                    <li>
+                        If you've signed the CLA before, the status check goes green, and you're done, your
+                        pull request is ready to be reviewed and merged.
+                    </li>
+                    <li>
+                        If you have not signed the CLA, the pull request will receive a comment annotated 
+                        with the agreement and more information about signing the agreement. You will reply
+                        with a comment if you accept the agreement yourself, or, if you've been authorized to
+                        sign it on behalf of your company, there is syntax for that as well.
+                    </li>
+                    <li>
+                        After signing, the status check will pass and you're all set. <strong>Thanks for your contribution!</strong>
+                    </li>
+                    <li>
+                        <em>NOTE:</em><br />
+                        If you're an active Microsoft employee or vendor, and have a linked GitHub account,
+                        the check will also go green. Microsoft employees can learn more about linking at 
+                        <a href="https://aka.ms/opensource" target="_new">aka.ms/opensource</a>.
+                    </li>
+                </ul>
+            </div>
+
+
+            <div class="pb-6">
+                <h3 class="h3">.NET Foundation CLA</h3>
+                <p>
+                    The <a href="https://dotnetfoundation.org/" target="_new">.NET Foundation</a> is a
+                    501(c)(6) non-profit organization, which was established to support an innovative,
+                    commercially friendly, open-source ecosystem around the .NET platform.
+                </p>
+                <p>
+                    While Microsoft assists with infrastructure alignment, the foundation maintains
+                    a separate CLA. You can read more about this process at 
+                    <a target="_new" href="https://cla.dotnetfoundation.org/">https://cla.dotnetfoundation.org/</a>. 
+                    Even Microsoft employees must sign the .NET Foundation CLA to cover their contributions to
+                    the community.
+                </p>
+            </div>
+
+            <div class="pb-6">
+                <h3 class="h3">Corporate CLA (CCLA)</h3>
+                <p>
+                    Microsoft does not typically participate in corporate CLA agreements, given the
+                    scale and logistics challenge.
+                </p>
+                <p>
+                    However, we recognize that some companies, especially those in highly regulated industries,
+                    need to have the ability to explicitly manage specific people who have access to participate
+                    in Microsoft projects. To enable these scenarios, an authorized individual or group from such
+                    a company can receive a special "CCLA repository" that will allow your firm to manually manage
+                    specific GitHub logins that are authorized on behalf of your company. You can also use GitHub Actions
+                    or other technology to customize and automate this list.
+                </p>
+                <p>
+                    A CCLA repository is a bespoke process. If you feel your company is a good fit for this,
+                    please reach out to the Microsoft Open Source Programs Office at <a href="mailto:opensource@microsoft.com">opensource@microsoft.com</a>.
+                </p>
+            </div>
+        </div>
+    </div>
 
 </article>

--- a/cla.html
+++ b/cla.html
@@ -28,17 +28,11 @@ permalink: /cla/
 
     <div class="wrapper my-6 py-4">
         <div class="col-md-10 col-lg-7 mx-auto longform">
-            <p class="p-lg">
-                TBD.
-            </p>
-
-            <br />
-            <br />
-
             <div class="pb-6">
                 <h3 class="h3">Review the CLA document</h3>
                 <p>
-                    Download the <a href="/pdf/microsoft-contribution-license-agreement.pdf" target="_new">Microsoft Contributor License Agreement (CLA) PDF</a> document if you need.
+                    Download the <a href="/pdf/microsoft-contribution-license-agreement.pdf" 
+                    target="_new">Microsoft Contributor License Agreement as a PDF</a> document if you need.
                 </p>
             </div>
             <div class="pb-6">


### PR DESCRIPTION
As we modernize and update the Microsoft Contributor License Agreement (CLA) experience, we are consolidating resources, and will be redirecting the `cla.opensource.microsoft.com` endpoint to `opensource.microsoft.com/cla` instead, to help inform people about the process, any specifics, the CCLA info, and also to point to a PDF of the CLA document.

This is preparing that work.