### PR TITLE
Update footer.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -48,7 +48,7 @@
                 <a href="https://careers.microsoft.com/us/en/search-results?keywords=open%20source" target="_new">Jobs</a>
             </li>
             <li>
-                <a href="https://cloudblogs.microsoft.com/opensource" target="_new">Blog</a>
+                <a href="https://opensource.microsoft.com/blog/" target="_new">Blog</a>
             </li>
             <li>
                 <a href="{{ '/codeofconduct/' | relative_url }}">Code of Conduct</a>


### PR DESCRIPTION
The current footer link for Blog points to:

https://cloudblogs.microsoft.com/opensource

However this link is redirected to:

https://opensource.microsoft.com/blog/

My simple PR points to the correct url.