### PR TITLE
Update Dapr to CNCF Graduated level

### DIFF
--- a/_projects/dapr.md
+++ b/_projects/dapr.md
@@ -1,6 +1,6 @@
 ---
 title: Dapr
-description: An event-driven, portable runtime for building microservices on cloud and edge. Dapr is a Cloud Native Computing Foundation incubating project.
+description: An event-driven, portable runtime for building microservices on cloud and edge. Dapr is a Cloud Native Computing Foundation graduated project.
 linkText: Get involved in Dapr
 projectUrl: https://dapr.io/
 logo: dapr.svg


### PR DESCRIPTION
Dapr moved from CNCF Incubating to Graduated level on October 30, 2024, source: https://www.cncf.io/projects/dapr/ Creating this PR to update this change. 