### PR TITLE
Updated language-specific links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,6 @@ This project is maintained by Microsoft's Open Source Programs Office (OSPO) wit
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
 trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+[Microsoft Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Thanks for your understanding.
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft 
 trademarks or logos is subject to and must follow 
-[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+[Microsoft Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks).
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
 

--- a/src/app/codeofconduct/page.tsx
+++ b/src/app/codeofconduct/page.tsx
@@ -166,7 +166,7 @@ export default function CodeOfConduct() {
               Expanding scope to include external impact on community health inspired by <a 
               href="https://opensource.facebook.com/code-of-conduct" className="link-standard" 
               target="_new">Facebook's Open Source Code of Conduct</a> and <a 
-              href="https://www.mozilla.org/en-US/about/governance/policies/participation/" 
+              href="https://www.mozilla.org/about/governance/policies/participation/" 
               className="link-standard" target="_new">Mozilla's Community Participation Guidelines</a>.
             </p>
             <p>

--- a/src/app/components/Azure.tsx
+++ b/src/app/components/Azure.tsx
@@ -12,7 +12,7 @@ export default function Azure() {
         <div className="col-md-6 col-lg-5 mb-4 mb-md-0">
           <h3 className="h5 text-brand font-weight-600 mb-2">Innovate faster and more securely with open source on Azure</h3>
           <p>Build on a highly secure cloud platform designed to protect your data and business assets, including proactive, comprehensive compliance coverage.  Gain the flexibility to move your app anywhere. Operate seamlessly and elastically, on-premises, in hybrid or multicloud environments, or at the edge.</p>
-          <div className="link-arrow-external mt-4"><a href="https://azure.microsoft.com/en-us/solutions/open-source/#overview">Learn more about open source on Azure</a></div>
+          <div className="link-arrow-external mt-4"><a href="https://azure.microsoft.com/solutions/open-source/#overview">Learn more about open source on Azure</a></div>
         </div>
 
         {/*

--- a/src/app/program/Tools.tsx
+++ b/src/app/program/Tools.tsx
@@ -210,8 +210,7 @@ export default function Tools() {
         <a href="https://learn.microsoft.com/azure/devops/reference/add-modify-wit?view=azure-devops-2020"
           rel="noopener"
           target="_blank">Work Item Tracking extensibility features</a>{' '}
-        and the{' '}
-        <a href="https://learn.microsoft.com/rest/api/azure/devops/wit/?view=azure-devops-rest-5.1"
+        and the <a href="https://learn.microsoft.com/rest/api/azure/devops/wit/?view=azure-devops-rest-5.1"
           rel="noopener"
           target="_blank">Azure DevOps REST API</a>.
       </p>

--- a/src/app/program/Tools.tsx
+++ b/src/app/program/Tools.tsx
@@ -61,7 +61,7 @@ export default function Tools() {
         <li><strong><a
           target="_blank"
           rel="noopener"
-          href="https://azure.microsoft.com/en-us/services/devops/pipelines/">Azure Pipelines</a></strong>{' '}
+          href="https://azure.microsoft.com/services/devops/pipelines/">Azure Pipelines</a></strong>{' '}
           can be exposed to public, open communities,{' '}
           allowing many Microsoft projects to continue using the build system they've been{' '}
           using for many years, but with a collaborative angle.
@@ -206,11 +206,12 @@ export default function Tools() {
         and eventually completing any necessary reviews.
       </p>
       <p>
-        This system is built by using the
-        <a href="https://docs.microsoft.com/en-us/azure/devops/reference/add-modify-wit?view=azure-devops-2020"
+        This system is built by using the{' '}
+        <a href="https://learn.microsoft.com/azure/devops/reference/add-modify-wit?view=azure-devops-2020"
           rel="noopener"
-          target="_blank">Work Item Tracking extensibility features</a>
-        and the <a href="https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/?view=azure-devops-rest-5.1"
+          target="_blank">Work Item Tracking extensibility features</a>{' '}
+        and the{' '}
+        <a href="https://learn.microsoft.com/rest/api/azure/devops/wit/?view=azure-devops-rest-5.1"
           rel="noopener"
           target="_blank">Azure DevOps REST API</a>.
       </p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -107,7 +107,7 @@ export default function Footer() {
                       </a>
                   </li>
                   <li>
-                      <a href="https://privacy.microsoft.com/en-us/privacystatement" target="_blank">Privacy & Cookies</a>
+                      <a href="https://privacy.microsoft.com/privacystatement" target="_blank">Privacy & Cookies</a>
                   </li>
                   <li id="manageCookies" data-require-javascript="yes" data-javascript-show="immediate">
                       <a href="#" onClick={() => {
@@ -125,7 +125,7 @@ export default function Footer() {
                     </a>
                   </li>
                   <li>
-                      <a href="https://www.microsoft.com/en-us/legal/intellectualproperty/copyright/default.aspx" target="_blank">Terms</a>
+                      <a href="https://www.microsoft.com/legal/intellectualproperty/copyright/default.aspx" target="_blank">Terms</a>
                   </li>
                   <li>
                       <a href="https://www.microsoft.com/trademarks" target="_blank">Trademarks</a>


### PR DESCRIPTION
Removed `en-us` from links that are used, updated a couple to current locations, and fixed (_I think_) a spacing issue.