### PR TITLE
Update Discord URL

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,7 +21,7 @@ export default function Footer() {
                               <ul className="list-style-none">
 
                                   <li>
-                                      <a className="mt-4 link-arrow-external" href="https://discord.com/invite/2PtM9ZaU" target="_blank" rel= "noopener">
+                                      <a className="mt-4 link-arrow-external" href="https://discord.gg/microsoft-open-source" target="_blank" rel= "noopener">
                                           <img className="mr-2" src="/images/discord.svg" alt="Discord icon" title="Discord icon" />
                                           Microsoft Open Source
                                       </a>


### PR DESCRIPTION
This PR updates the Discord URL from a manual invite to the friendly link (that does not expire). Another alternative is https://aka.ms/open-source-discord (via: https://github.com/microsoft/open-source-discord ).