### PR TITLE
Fix: Language filter shows incorrect results (C# / C++ display C projects)

### DIFF
--- a/src/app/projects/explore/dynamic.tsx
+++ b/src/app/projects/explore/dynamic.tsx
@@ -56,7 +56,7 @@ export default function ExploreProjectsDynamic() {
 
   const handleSearch = (e: any) => {
     e.preventDefault();
-    fetch(`/api/repos?q=${encodeURIComponent(searchQuery)}&languages=${filters.join(',')}`)
+    fetch(`/api/repos?q=${encodeURIComponent(searchQuery)}&languages=${filters.map((f) => encodeURIComponent(f)).join(',')}`)
       .then((response) => response.json())
       .then((data: ProjectsSearchResponse) => {
         setProjects(data.repos);
@@ -70,7 +70,7 @@ export default function ExploreProjectsDynamic() {
         : [...prevFilters, filter];
 
       // Trigger a new search with updated filters
-      fetch(`/api/repos?q=${encodeURIComponent(searchQuery)}&languages=${newFilters.join(',')}`)
+      fetch(`/api/repos?q=${encodeURIComponent(searchQuery)}&languages=${newFilters.map((f) => encodeURIComponent(f)).join(',')}`)
         .then((response) => response.json())
         .then((data: ProjectsSearchResponse) => {
           setProjects(data.repos);


### PR DESCRIPTION
Fix language filter on Explore Projects page for C# and C++. Previously, selecting C# or C++ returned projects for C due to improper URL encoding. Updated fetch requests in dynamic.tsx to use encodeURIComponent(). Only minimal changes in dynamic.tsx; no other files edited.