### PR TITLE
Adding internal link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Other content includes:
 - OpenAtMicrosoft X account
 - This repository
 
+Microsoft-internal information is available regarding the site at [https://docs.opensource.microsoft.com/community/in-public/public-site/](https://docs.opensource.microsoft.com/community/in-public/public-site/) (requires corporate authentication).
+
 # Contributing
 
 ## Code of Conduct


### PR DESCRIPTION
For Microsoft employees with more general questions about the site's infrastructure, adding a link to the internal docs page on the resource.