### PR TITLE
additional focus fix

### DIFF
--- a/src/app/styles/base/baseHtml.scss
+++ b/src/app/styles/base/baseHtml.scss
@@ -103,8 +103,17 @@ hr {
 //  Keyboard Focus Indicator
 //  Ensures all interactive controls show a clearly visible focus
 //  indicator when navigated via keyboard (WCAG 2.4.7 Focus Visible).
+//  Use !important so this wins over component-level outline resets.
 // ---------------------------------------------------------------------
 :focus-visible {
-    outline: 2px solid $brand;
+    outline: 2px solid $brand !important;
     outline-offset: 2px;
+}
+
+// Fallback for browsers without :focus-visible support.
+@supports not selector(:focus-visible) {
+    :focus {
+        outline: 2px solid $brand !important;
+        outline-offset: 2px;
+    }
 }


### PR DESCRIPTION
This pull request strengthens the keyboard focus indicator styles to ensure better accessibility and cross-browser compatibility. The main improvements are making the focus outline harder to override and providing a fallback for browsers that do not support the `:focus-visible` selector.

Accessibility and browser compatibility improvements:

* Updated the `:focus-visible` selector to use `!important` on the outline, ensuring it takes precedence over component-level resets.
* Added a fallback using `@supports not selector(:focus-visible)` to apply the same focus outline to `:focus` when `:focus-visible` is not supported, improving accessibility in older browsers.